### PR TITLE
Fix bug where shimmer stays visible when there are no followed publications

### DIFF
--- a/app/src/main/java/com/cornellappdev/volume/fragments/PublicationsFragment.kt
+++ b/app/src/main/java/com/cornellappdev/volume/fragments/PublicationsFragment.kt
@@ -125,6 +125,10 @@ class PublicationsFragment : Fragment() {
                     val adapter = followingPublicationsRV.adapter as FollowingHorizontalAdapter
                     adapter.clear()
                 }
+                if (followingPublicationsIDs.isNullOrEmpty()) {
+                    binding.shimmerFollowingPublication.visibility = View.GONE
+                }
+
 
                 // It's important that handleMorePublicationObservable comes after handleFollowingObservable
                 // since we filter what other publications to display based on what publications the user follows.

--- a/app/src/main/res/layout/fragment_publications.xml
+++ b/app/src/main/res/layout/fragment_publications.xml
@@ -90,6 +90,8 @@
                     android:id="@+id/shimmer_following_publication"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp"
+                    android:layout_marginLeft="5dp"
                     app:shimmer_repeat_mode="restart"
                     app:layout_constraintTop_toBottomOf="@id/iv_following_header"
                     app:shimmer_shape="linear">

--- a/app/src/main/res/layout/fragment_publications.xml
+++ b/app/src/main/res/layout/fragment_publications.xml
@@ -92,6 +92,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="15dp"
                     android:layout_marginLeft="5dp"
+                    android:layout_marginRight="5dp"
                     app:shimmer_repeat_mode="restart"
                     app:layout_constraintTop_toBottomOf="@id/iv_following_header"
                     app:shimmer_shape="linear">


### PR DESCRIPTION
## Overview
Added additional logic to make sure the shimmer on the publications page is hidden when there are no followed publications.

## Changes Made
- added logic to PublicationsFragment.kt to hide shimmer if there are no followed publications
- fixed margins on followed publications in fragment_publications.xml

## Test Coverage
Manual testing by following 0, 1, 2 and all publications.

## Related PRs
#30 Fix Volume Shutter Bug and Implement Shimmer Feature
